### PR TITLE
gmtb/develop: update hera config

### DIFF
--- a/src/conf/module-setup.csh.inc
+++ b/src/conf/module-setup.csh.inc
@@ -8,8 +8,7 @@ if ( { test -d /lfs3 } ) then
             source /apps/lmod/lmod/init/$__ms_shell
     endif
     module purge
-#else if ( { test -d /scratch1 } ) then
-else if ( { test -d /tds_scratch1 } ) then
+else if ( { test -d /scratch1 } ) then
     # We are on NOAA Hera
     if ( ! { module help >& /dev/null } ) then
         source /apps/lmod/lmod/init/$__ms_shell

--- a/src/conf/module-setup.sh.inc
+++ b/src/conf/module-setup.sh.inc
@@ -22,8 +22,7 @@ if [[ -d /lfs3 ]] ; then
         source /apps/lmod/lmod/init/$__ms_shell
     fi
     module purge
-#elif [[ -d /scratch1 ]] ; then
-elif [[ -d /tds_scratch1 ]] ; then
+elif [[ -d /scratch1 ]] ; then
     # We are on NOAA Hera
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/lmod/init/$__ms_shell

--- a/src/incmake/env/rdhpcs/detect.mk
+++ b/src/incmake/env/rdhpcs/detect.mk
@@ -4,11 +4,11 @@
 #
 ########################################################################
 
-ifneq (,$(and $(wildcard /scratch1),$(wildcard /scratch2)))
+ifneq (,$(and $(wildcard /scratch1),$(wildcard /scratch2),$(shell hostname | grep -i hfe)))
   NEMS_COMPILER?=intel
   $(call add_build_env,hera.$(NEMS_COMPILER),env/rdhpcs/hera.$(NEMS_COMPILER).mk)
 else
-  ifneq (,$(and $(wildcard /scratch4),$(wildcard /scratch3)))
+  ifneq (,$(and $(wildcard /scratch4),$(wildcard /scratch3),$(shell hostname | grep -i tfe)))
     NEMS_COMPILER?=intel
     $(call add_build_env,theia.$(NEMS_COMPILER),env/rdhpcs/theia.$(NEMS_COMPILER).mk)
   else

--- a/src/incmake/env/rdhpcs/detect.mk
+++ b/src/incmake/env/rdhpcs/detect.mk
@@ -4,24 +4,21 @@
 #
 ########################################################################
 
-ifneq (,$(and $(wildcard /scratch4),$(wildcard /scratch3)))
+ifneq (,$(and $(wildcard /scratch1),$(wildcard /scratch2)))
   NEMS_COMPILER?=intel
-  $(call add_build_env,theia.$(NEMS_COMPILER),env/rdhpcs/theia.$(NEMS_COMPILER).mk)
+  $(call add_build_env,hera.$(NEMS_COMPILER),env/rdhpcs/hera.$(NEMS_COMPILER).mk)
 else
-  ifneq (,$(and $(wildcard /lfs1),$(wildcard /lfs3)))
+  ifneq (,$(and $(wildcard /scratch4),$(wildcard /scratch3)))
     NEMS_COMPILER?=intel
-    $(call add_build_env,jet.$(NEMS_COMPILER),env/rdhpcs/jet.$(NEMS_COMPILER).mk)
+    $(call add_build_env,theia.$(NEMS_COMPILER),env/rdhpcs/theia.$(NEMS_COMPILER).mk)
   else
-    ifneq (,$(shell hostname | grep -i gaea))
+    ifneq (,$(and $(wildcard /lfs1),$(wildcard /lfs3)))
       NEMS_COMPILER?=intel
-      $(call add_build_env,gaea.$(NEMS_COMPILER),env/rdhpcs/gaea.$(NEMS_COMPILER).mk)
+      $(call add_build_env,jet.$(NEMS_COMPILER),env/rdhpcs/jet.$(NEMS_COMPILER).mk)
     else
-      # DH* 
-      #ifneq (,$(and $(wildcard /scratch1),$(wildcard /scratch2)))
-      ifneq (,$(wildcard /tds_scratch1))
-      # *DH juno test system
+      ifneq (,$(shell hostname | grep -i gaea))
         NEMS_COMPILER?=intel
-        $(call add_build_env,hera.$(NEMS_COMPILER),env/rdhpcs/hera.$(NEMS_COMPILER).mk)
+        $(call add_build_env,gaea.$(NEMS_COMPILER),env/rdhpcs/gaea.$(NEMS_COMPILER).mk)
       endif
     endif
   endif


### PR DESCRIPTION
Update the logic to detect hera or theia in 
src/incmake/env/rdhpcs/detect.mk, because both theia and hera have /scratch1 through /scratch4 mounted for the transition period. The changes look more dramatic than they are, because testing for hera is now the first action, all others are moved into the first "else" block.

Note: the legacy logic in src/conf/module-setup.{sh,csh}.inc detects systems with /scratch1 as hera and systems with /scratch4 as theia. Since the action to take is limited to this this script and is identical for both systems, it is ok that during the transition period theia is detected as hera within the scope of the script.

Associated PRs: 
https://github.com/NCAR/NEMS/pull/2
https://github.com/NCAR/NEMSfv3gfs/pull/230

For testing, see https://github.com/NCAR/NEMSfv3gfs/pull/230 