### PR TITLE
Bugfix for NemsCompset detection of Theia/Hera

### DIFF
--- a/src/incmake/env/rdhpcs/detect.mk
+++ b/src/incmake/env/rdhpcs/detect.mk
@@ -4,11 +4,11 @@
 #
 ########################################################################
 
-ifneq (,$(and $(wildcard /scratch1),$(wildcard /scratch2),$(shell hostname | grep -i hfe)))
+ifneq (,$(and $(wildcard /scratch1),$(and $(wildcard /scratch2),$(wildcard /xcatpost))))
   NEMS_COMPILER?=intel
   $(call add_build_env,hera.$(NEMS_COMPILER),env/rdhpcs/hera.$(NEMS_COMPILER).mk)
 else
-  ifneq (,$(and $(wildcard /scratch4),$(wildcard /scratch3),$(shell hostname | grep -i tfe)))
+  ifneq (,$(and $(wildcard /scratch4),$(and $(wildcard /scratch3),$(wildcard /tftpboot))))
     NEMS_COMPILER?=intel
     $(call add_build_env,theia.$(NEMS_COMPILER),env/rdhpcs/theia.$(NEMS_COMPILER).mk)
   else


### PR DESCRIPTION
NEMSCompsetRun does not work with the shell-hostname command, test for additional directories unique to Theia or Hera. Tested together with Tested together with https://github.com/NCAR/NEMS/pull/3 and https://github.com/NCAR/NEMSfv3gfs/pull/234, https://github.com/NCAR/ccpp-physics/pull/308 and https://github.com/NCAR/FV3/pull/195, see https://github.com/NCAR/FV3/pull/195 for regression testing info.