### PR TITLE
Update CCPP.mk for moving ccpp underneath FV3

### DIFF
--- a/src/incmake/component_CCPP.mk
+++ b/src/incmake/component_CCPP.mk
@@ -3,15 +3,18 @@ ccpp_mk=$(CCPP_BINDIR)/ccpp.mk
 all_component_mk_files+=$(ccpp_mk)
 
 # Location of source code and installation
-CCPP_SRCDIR?=$(ROOTDIR)/ccpp
-CCPP_BINDIR?=$(ROOTDIR)/ccpp
+CCPP_SRCDIR?=$(ROOTDIR)/FV3/ccpp
+CCPP_BINDIR?=$(ROOTDIR)/FV3/ccpp
+
+# Build directory - set to FV3 (later fv3atm) for old make (i.e. in-source) build
+CCPP_BUILDDIR?=$(ROOTDIR)/FV3
 
 # Make sure we have a model that supports CCPP:
 ifeq (,$(findstring FV3,$(COMPONENTS)))
   $(error CCPP requires FV3)
 else
   # Ensure the model is selected.
-  override CCPP_CONFOPT += --config=ccpp/config/ccpp_prebuild_config.py
+  override CCPP_CONFOPT += --config=$(CCPP_SRCDIR)/config/ccpp_prebuild_config.py --builddir=$(CCPP_BUILDDIR)
   override CCPP_MAKEOPT ?= $(FV3_MAKEOPT)
   override CCPP_BUILDOPT ?= $(FV3_BUILDOPT)
 endif
@@ -47,7 +50,7 @@ $(ccpp_mk): configure
 	set -xue                                                        ; \
 	export PATH_CCPP="$(CCPP_SRCDIR)"                               ; \
 	cd $(ROOTDIR)                                                   ; \
-	./ccpp/framework/scripts/ccpp_prebuild.py $(CCPP_CONFOPT)       ; \
+	$$PATH_CCPP/framework/scripts/ccpp_prebuild.py $(CCPP_CONFOPT)  ; \
 	cd $$PATH_CCPP                                                  ; \
 	./build_ccpp.sh ${BUILD_TARGET} "$$PATH_CCPP" $(ccpp_mk)          \
 	  "$(CCPP_MAKEOPT)" NO NO                                       ; \


### PR DESCRIPTION
Associated PRs:

https://github.com/NCAR/ccpp-framework/pull/230
https://github.com/NCAR/ccpp-physics/pull/340
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/5
https://github.com/NOAA-EMC/fv3atm/pull/1
https://github.com/ufs-community/ufs-weather-model/pull/1
https://github.com/NCAR/NEMS/pull/14

Changes for NEMS:
- src/incmake/component_CCPP.mk: update CCPP source/install directories and set CCPP build directory
