### PR TITLE
dtc/develop: update from develop 2020/01/27

### DIFF
--- a/tests/apps.def
+++ b/tests/apps.def
@@ -12,9 +12,9 @@ APP FV3-MOM6-CICE5  COMPSETS -f
 APP FV3GFS-GSDCHEM  COMPSETS -f
 
 # URLs of each application's repository.  Default is gerrit:APPNAME
-APP NEMSfv3gfs      URL gerrit:NEMSfv3gfs
+APP NEMSfv3gfs      URL https://github.com/ufs-community/ufs-weather-model
 APP WW3-FV3         URL gerrit:EMC_FV3-GSDCHEM-WW3
-APP FV3-MOM6-CICE5  URL gerrit:EMC_FV3-MOM6-CICE5
+APP FV3-MOM6-CICE5  URL https://github.com/ufs-community/ufs-s2s-model
 APP FV3GFS-GSDCHEM  URL gerrit:EMC_FV3GFS-GSDCHEM
 
 # Shell expressions that generate scrub space for a given $username

--- a/tests/rtgen
+++ b/tests/rtgen
@@ -749,8 +749,8 @@ def decide_project_gaea():
 # WCOSS project detection
 
 def decide_project_wcoss():
-    """!Placeholder for future development; returns "FV3GFS-T2O" """
-    return 'FV3GFS-T2O'
+    """!Placeholder for future development; returns "GFS-DEV" """
+    return 'GFS-DEV'
 
 def decide_tmp_wcoss(pex):
     """!Placeholder for future development; returns "/ptmpp/$USER"


### PR DESCRIPTION
PLACEHOLDER

Change acc# on WCOSS to GFS-DEV (#17)
* Revert old src/incmake/component_CCPP.mk
* Got back src/incmake/component_CCPP.mk file
* NEMSfv3gfs and FV3-MOM6-CICE5 moved to github
* Change account number form FV3GFS-T2O to GFS-DEV on WCOSS machines.